### PR TITLE
Amend display of unreachable lights in UI

### DIFF
--- a/app/src/androidTest/java/com/thaddeussoftware/tinge/ControllerTestHelpers.kt
+++ b/app/src/androidTest/java/com/thaddeussoftware/tinge/ControllerTestHelpers.kt
@@ -1,0 +1,52 @@
+package com.thaddeussoftware.tinge
+
+import androidx.databinding.ObservableField
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.ControllerInternalStageableProperty
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.HubController
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.LightController
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.LightGroupController
+
+object ControllerTestHelpers {
+    /**
+     * @return
+     * An empty [LightController] instance for testing.
+     *
+     * All values will be initially set to null.
+     *
+     * This is not backed by any logic (such as logic to set aggregate properties or change colour
+     * modes), so test classes are responsible for setting all properties.
+     * */
+    fun getEmptyLightController(
+            hubController: HubController = getEmptyHubController()
+    ): LightController {
+        return object: LightController {
+            override val hubController = hubController
+            override val isReachable = ObservableField<Boolean>()
+            override val doesSupportColorMode = true
+            override val doesSupportTemperatureMode = true
+            override val lightId = ""
+            override val displayName = ControllerInternalStageableProperty<String>()
+            override val isInColorMode = ControllerInternalStageableProperty<Boolean>()
+            override val isOn = ControllerInternalStageableProperty<Boolean?>()
+            override val brightness = ControllerInternalStageableProperty<Float?>()
+            override val hue = ControllerInternalStageableProperty<Float>()
+            override val saturation = ControllerInternalStageableProperty<Float>()
+            override val miredColorTemperature = ControllerInternalStageableProperty<Float>()
+            override val colorTemperatureInSupportedRange = ControllerInternalStageableProperty<Float>()
+        }
+    }
+
+    fun getEmptyHubController(): HubController {
+        return object: HubController() {
+            override val ipAddress = ""
+            override val hubController: HubController
+                get() = this
+            override val parentLightGroupController: LightGroupController? = null
+            override val lightsNotInSubgroup = ArrayList<LightController>()
+            override val lightsInGroupOrSubgroups = ArrayList<LightController>()
+            override val lightGroups = ArrayList<LightGroupController>()
+            override val id = ""
+            override val name = ControllerInternalStageableProperty<String?>("")
+        }
+    }
+}

--- a/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightView/lightViewModel/IsReachablePropertyTests.kt
+++ b/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightView/lightViewModel/IsReachablePropertyTests.kt
@@ -1,0 +1,52 @@
+package com.thaddeussoftware.tinge.ui.lights.lightView.lightViewModel
+
+import androidx.databinding.Observable
+import com.thaddeussoftware.tinge.ControllerTestHelpers
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.LightController
+import com.thaddeussoftware.tinge.ui.lights.lightView.LightViewModel
+import junit.framework.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class IsReachablePropertyTests {
+
+    /**
+     * Wait some time to ensure that observables have time to get called and take effect
+     * */
+    private val TIME_TO_WAIT_MS: Long = 20
+
+    private var wasCorrectMethodCalled = false
+
+    private lateinit var lightController: LightController
+
+
+    @Before
+    fun setup() {
+        lightController = ControllerTestHelpers.getEmptyLightController()
+    }
+
+
+    @Test
+    fun isReachableChangedOnController_isReachableUpdatedOnViewModel() {
+        // Arrange:
+        lightController.isReachable.set(false)
+        val lightViewModel = LightViewModel(lightController)
+
+        lightViewModel.isReachable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
+            override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
+                assertEquals(true, lightViewModel.isReachable.get())
+                wasCorrectMethodCalled = true
+            }
+        })
+
+        // Act:
+        lightController.isReachable.set(true)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertTrue(wasCorrectMethodCalled)
+    }
+
+
+}

--- a/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightView/lightViewModel/ShowTopRightExpandButtonTests.kt
+++ b/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightView/lightViewModel/ShowTopRightExpandButtonTests.kt
@@ -1,0 +1,251 @@
+package com.thaddeussoftware.tinge.ui.lights.lightView.lightViewModel
+
+import com.thaddeussoftware.tinge.ControllerTestHelpers
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.LightController
+import com.thaddeussoftware.tinge.ui.lights.lightView.LightViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ShowTopRightExpandButtonTests {
+
+    /**
+     * Wait some time to ensure that observables have time to get called and take effect
+     * */
+    private val TIME_TO_WAIT_MS: Long = 20
+
+    /**
+     * Blank fake [LightController] with no logic in it
+     * */
+    private lateinit var lightController: LightController
+
+
+    @Before
+    fun setup() {
+        lightController = ControllerTestHelpers.getEmptyLightController()
+    }
+
+
+
+    // region Testing initial LightViewModel values
+
+    /**
+     * Tests that isReachable true and isOn false sets showTopRightExpandButton to false
+     * */
+    @Test
+    fun isReachableTrue_isOnFalse___showTopRightExpandButtonFalse() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        // Act:
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(false, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isReachable true and isOn true sets showTopRightExpandButton to true
+     * */
+    @Test
+    fun isReachableTrue_isOnTrue___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(true)
+
+        // Act:
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isReachable false and isOn false sets showTopRightExpandButton to true
+     * */
+    @Test
+    fun isReachableFalse_isOnFalse___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(false)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        // Act:
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isReachable false and isOn true sets showTopRightExpandButton to true
+     * */
+    @Test
+    fun isReachableFalse_isOnTrue___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(false)
+        lightController.isOn.setValueRetrievedFromHub(true)
+
+        // Act:
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    // endregion
+
+
+
+    //region Modifying isOn controller value
+
+    /**
+     * Tests that isOn being staged to true correctly updates showTopRightExpandButton
+     * */
+    @Test
+    fun isReachableTrue_isOnFalse___isOnTrueStaged___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isOn.stageValue(true)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isOn being staged to false correctly updates showTopRightExpandButton
+     * */
+    @Test
+    fun isReachableTrue_isOnTrue___isOnFalseStaged___showTopRightExpandButtonFalse() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(true)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isOn.stageValue(false)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(false, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isOn being updated from hub to true correctly updates showTopRightExpandButton
+     * */
+    @Test
+    fun isReachableTrue_isOnFalse___isOnTrueReceivedFromHub___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isOn.setValueRetrievedFromHub(true)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isOn being updated from hub to false correctly updates showTopRightExpandButton
+     * */
+    @Test
+    fun isReachableTrue_isOnTrue___isOnFalseReceivedFromHub___showTopRightExpandButtonFalse() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(true)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(false, viewModel.showTopRightExpandButton.get())
+    }
+
+    //endregion
+
+
+
+    //region Modifying isReachable controller value
+
+    /**
+     * Tests that isReachable being updated from hub to false correctly updates
+     * showTopRightExpandButton to true
+     * */
+    @Test
+    fun isReachableTrue_isOnTrue___isReachableFalseSet___showTopRightExpandButtonTrue() {
+        // Arrange:
+        lightController.isReachable.set(true)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isReachable.set(false)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(true, viewModel.showTopRightExpandButton.get())
+    }
+
+    /**
+     * Tests that isReachable being updated from hub to true correctly updates
+     * showTopRightExpandButton to false
+     * */
+    @Test
+    fun isReachableFalse_isOnTrue___isReachableFalseSet___showTopRightExpandButtonFalse() {
+        // Arrange:
+        lightController.isReachable.set(false)
+        lightController.isOn.setValueRetrievedFromHub(false)
+
+        val viewModel = LightViewModel(lightController)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        lightController.isReachable.set(true)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(false, viewModel.showTopRightExpandButton.get())
+    }
+
+    //endregion
+}

--- a/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightsUiHelperTests/BindObservableBrightnessViewModelPropertyToControllerTests.kt
+++ b/app/src/androidTest/java/com/thaddeussoftware/tinge/ui/lights/lightsUiHelperTests/BindObservableBrightnessViewModelPropertyToControllerTests.kt
@@ -1,0 +1,373 @@
+package com.thaddeussoftware.tinge.ui.lights.lightsUiHelperTests
+
+import androidx.databinding.ObservableField
+import com.thaddeussoftware.tinge.deviceControlLibrary.generic.controller.ControllerInternalStageableProperty
+import com.thaddeussoftware.tinge.ui.lights.LightsUiHelper
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class BindObservableBrightnessViewModelPropertyToControllerTests {
+
+    /**
+     * Wait some time to ensure that observables have time to get called and take effect
+     * */
+    private val TIME_TO_WAIT_MS: Long = 20
+
+    lateinit var isOnStageableProperty: ControllerInternalStageableProperty<Boolean?>
+    lateinit var brightnessStageableProperty: ControllerInternalStageableProperty<Float?>
+    lateinit var brightnessViewModelProperty: ObservableField<Float?>
+
+    @Before
+    fun setup() {
+        isOnStageableProperty = ControllerInternalStageableProperty()
+        brightnessStageableProperty = ControllerInternalStageableProperty()
+        brightnessViewModelProperty = ObservableField()
+    }
+
+    //region Initially binding observable
+
+    /**
+     * Tests when isOn is true
+     * */
+    @Test
+    fun isOnTrue___viewModelPropertySetToBrightness_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(0f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        // Act:
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(0f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests when isOn is false
+     * */
+    @Test
+    fun isOnFalse___viewModelPropertySetToMinusOne_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(0.5f)
+        isOnStageableProperty.setValueRetrievedFromHub(false)
+
+        // Act:
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(-1f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(0.5f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(false, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    //endregion
+
+
+
+    //region Binding observable then modifying controller properties
+
+    /**
+     * Tests that the isOn property being received from the hub behaves correctly
+     * */
+    @Test
+    fun isOnTrueReceivedFromHub___viewModelPropertySetToBrightness_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(0.5f)
+        isOnStageableProperty.setValueRetrievedFromHub(false)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0.5f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(0.5f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests that the isOn property being staged behaves correctly
+     * */
+    @Test
+    fun isOnFalseStaged___viewModelPropertySetToMinusOne_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(0.5f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        isOnStageableProperty.stageValue(false)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(-1f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(false, isOnStageableProperty.stagedValue)
+        assertEquals(0.5f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests that the brightness property being received from the hub behaves correctly when
+     * isOn is true
+     * */
+    @Test
+    fun isOnTrue___brightnessReceivedFromHub___viewModelPropertySetToBrightness_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessStageableProperty.setValueRetrievedFromHub(0.5f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0.5f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(0.5f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests that the brightness property being received from the hub behaves correctly when
+     * isOn is false
+     * */
+    @Test
+    fun isOnFalse___brightnessReceivedFromHub___viewModelPropertyStaysMinusOne_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(0.5f)
+        isOnStageableProperty.setValueRetrievedFromHub(false)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(-1f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(false, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests that the brightness property being staged hub behaves correctly when isOn is false
+     * */
+    @Test
+    fun isOnFalse___brightnessStaged___viewModelPropertySetToMinusOne_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(false)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessStageableProperty.stageValue(0.5f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(-1f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(0.5f, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(false, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    /**
+     * Tests that the brightness property being staged behaves correctly when isOn is true
+     * */
+    @Test
+    fun isOnTrue___brightnessStaged___viewModelPropertySetToBrightness_controllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessStageableProperty.stageValue(0.5f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0.5f, brightnessViewModelProperty.get())
+        // Make sure nothing in the internally stageable properties has changed:
+        assertEquals(0.5f, brightnessStageableProperty.stagedValue)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+    }
+
+    //endregion
+
+
+
+    //region Binding observable them modifying ViewModel property
+
+    /**
+     * Tests that the viewmodel property being modified to another brightness behaves correctly
+     * when isOn is true
+     * */
+    @Test
+    fun isOnTrue___viewModelPropertyMovedToAnotherBrightness___brightnessValueStaged_otherControllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessViewModelProperty.set(0.5f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0.5f, brightnessStageableProperty.stagedValue)
+        // Make sure no other internally stageable properties have changed:
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(null, isOnStageableProperty.stagedValue)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+
+        assertEquals(0.5f, brightnessViewModelProperty.get())
+    }
+
+    /**
+     * Tests that the viewmodel property being modified to off behaves correctly when isOn is true
+     * */
+    @Test
+    fun isOnTrue___viewModelPropertyMovedToOff___isOnValueStaged_otherControllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(true)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessViewModelProperty.set(-1f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(false, isOnStageableProperty.stagedValue)
+        // Make sure no other internally stageable properties have changed:
+        assertEquals(null, brightnessStageableProperty.stagedValue)
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(true, isOnStageableProperty.lastValueRetrievedFromHub)
+
+        assertEquals(-1f, brightnessViewModelProperty.get())
+    }
+
+    /**
+     * Tests that the viewmodel property being modified to a brightness behaves correctly
+     * when isOn is false
+     * */
+    @Test
+    fun isOnFalse___viewModelPropertyMovedToABrightness___brightnessValueStaged_isOnTrueStaged_otherControllerPropertiesUnchanged() {
+        // Arrange:
+        brightnessStageableProperty.setValueRetrievedFromHub(1f)
+        isOnStageableProperty.setValueRetrievedFromHub(false)
+
+        LightsUiHelper.bindObservableBrightnessViewModelPropertyToController(
+                brightnessViewModelProperty,
+                isOnStageableProperty,
+                brightnessStageableProperty)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Act:
+        brightnessViewModelProperty.set(0.5f)
+
+        Thread.sleep(TIME_TO_WAIT_MS)
+
+        // Assert:
+        assertEquals(0.5f, brightnessStageableProperty.stagedValue)
+        assertEquals(true, isOnStageableProperty.stagedValue)
+        // Make sure no other internally stageable properties have changed:
+        assertEquals(1f, brightnessStageableProperty.lastValueRetrievedFromHub)
+        assertEquals(false, isOnStageableProperty.lastValueRetrievedFromHub)
+
+        assertEquals(0.5f, brightnessViewModelProperty.get())
+    }
+
+    //endregion
+
+}

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/BindingAdapters.java
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/BindingAdapters.java
@@ -20,6 +20,20 @@ public class BindingAdapters {
         view.setLayoutParams(layoutParams);
     }
 
+    @BindingAdapter("android:layout_marginStart")
+    public static void setLayoutMarginStartFloat(View view, float marginStart) {
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        layoutParams.setMarginStart((int) marginStart);
+        view.setLayoutParams(layoutParams);
+    }
+
+    @BindingAdapter("android:layout_marginEnd")
+    public static void setLayoutMarginEndFloat(View view, float marginEnd) {
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        layoutParams.setMarginEnd((int) marginEnd);
+        view.setLayoutParams(layoutParams);
+    }
+
     @BindingAdapter("android:layout_marginLeft")
     public static void setLayoutMarginLeftFloat(View view, float marginLeft) {
         ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) view.getLayoutParams();

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/InnerLightViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/InnerLightViewModel.kt
@@ -5,7 +5,20 @@ import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
 import android.view.View
 import com.thaddeussoftware.tinge.ui.sliderView.SliderViewHandle
+import com.thaddeussoftware.tinge.ui.lights.lightView.LightViewModel
+import com.thaddeussoftware.tinge.ui.lights.groupView.GroupViewModel
+import com.thaddeussoftware.tinge.R
 
+/**
+ * Represents a ViewModel that contains an inner light view (With a title, a brightness slider,
+ * an expandable area containing hue and saturation sliders).
+ *
+ * This class exists in order to make large parts of shared behaviour from [LightViewModel] and
+ * [GroupViewModel] into one common class.
+ *
+ * [R.layout.view_inner_light] can then bind directly to this ViewModel, whether it is a
+ * [LightViewModel] or [GroupViewModel], meaning only one view implementation needs to exist.
+ * */
 abstract class InnerLightViewModel: ViewModel() {
 
     /**
@@ -28,24 +41,21 @@ abstract class InnerLightViewModel: ViewModel() {
     abstract val doesSupportColorMode: ObservableField<Boolean>
 
     /**
-     * Hue of the light from 0 - 1
-     * Null if unknown or this is a group with different values
+     * [SliderViewHandle]s for Hues to show in Hue slider (from 0 - 1)
      * */
     abstract val hueHandles: ObservableList<SliderViewHandle>
     /**
-     * Saturation of the light from 0 - 1
-     * Null if unknown or this is a group with different values
+     * [SliderViewHandle]s for Saturation values to show in Saturation slider (from 0 - 1)
      * */
     abstract val saturationHandles: ObservableList<SliderViewHandle>
     /**
-     * Brightness of the light from 0 - 1
-     * Null if unknown or this is a group with different values
+     * [SliderViewHandle]s for Brightness values to show in Brightness slider (from 0 - 1)
+     * Lights that are off should be set to -1.
      * */
     abstract val brightnessHandles: ObservableList<SliderViewHandle>
 
     /**
-     * White temperature of the light from 0 - 1
-     * Null if unknown or this is a group with different values
+     * [SliderViewHandle]s for White temperatures to show in White temperature slider (from 0 - 1)
      * */
     abstract val whiteTemperatureHandles: ObservableList<SliderViewHandle>
 
@@ -75,7 +85,18 @@ abstract class InnerLightViewModel: ViewModel() {
      * */
     abstract val displayName: ObservableField<String?>
 
+    /**
+     * This can be used to add a second line of information below [displayName]
+     * */
     abstract val secondaryInformation: ObservableField<String?>
+
+    /**
+     * Whether this light / group is currently reachable or not.
+     *
+     * Groups should always return true if the Hub that the group is in is reachable by the app,
+     * regardless of whether any of the lights in the group are reachable or not.
+     * */
+    abstract val isReachable: ObservableField<Boolean>
 
 
     abstract fun onExpandContractButtonClicked(view: View)

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/LightsUiHelper.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/LightsUiHelper.kt
@@ -33,24 +33,30 @@ object LightsUiHelper {
                     // Do nothing
                     Log.v("tinge", "LightsUiHelper brightness slider changed to null ???")
                 } else if (value < 0) {
-                    isOnStageableProperty.stageValue(false)
+                    if (isOnStageableProperty.lastValueRetrievedFromHub != false) {
+                        isOnStageableProperty.stageValue(false)
+                    }
                     Log.v("tinge", "LightsUiHelper brightness slider changed to off, setting light controller off ")
                 } else if (value >= 0f){
                     Log.v("tinge", "LightsUiHelper brightness slider changed, setting light controller brightness to: "+value)
-                    isOnStageableProperty.stageValue(true)
-                    brightnessStageableProperty.stageValue(value)
+                    if (isOnStageableProperty.lastValueRetrievedFromHub != true) {
+                        isOnStageableProperty.stageValue(true)
+                    }
+                    if (brightnessStageableProperty.lastValueRetrievedFromHub != value) {
+                        brightnessStageableProperty.stageValue(value)
+                    }
                 }
                 isPropertyBeingChangedByCode = false
             }
         })
 
         // When controller isOn property changed, UI property should be updated:
-        isOnStageableProperty.lastValueRetrievedFromHubObservable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
+        isOnStageableProperty.stagedValueOrLastValueFromHubObservable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
             override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
-                if (isOnStageableProperty.lastValueRetrievedFromHub == false) {
+                if (isOnStageableProperty.stagedValueOrLastValueFromHub == false) {
                     Log.v("tinge", "LightsUiHelper controller isOn set to false, updating slider")
                     brightnessViewModelProperty.set(-1f)
-                } else if (isOnStageableProperty.lastValueRetrievedFromHub == true) {
+                } else if (isOnStageableProperty.stagedValueOrLastValueFromHub == true) {
                     Log.v("tinge", "LightsUiHelper controller isOn set to true, updating slider")
                     brightnessViewModelProperty.set(brightnessStageableProperty.stagedValueOrLastValueFromHub)
                 } else {
@@ -61,12 +67,12 @@ object LightsUiHelper {
         })
 
         // When controller brightness property changed, UI property should be updated:
-        brightnessStageableProperty.lastValueRetrievedFromHubObservable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
+        brightnessStageableProperty.stagedValueOrLastValueFromHubObservable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
             override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
-                if (isOnStageableProperty.lastValueRetrievedFromHub == false) {
+                if (isOnStageableProperty.stagedValueOrLastValueFromHub == false) {
                     Log.v("tinge", "LightsUiHelper controller brightness changed, isOn is false, updating slider")
                     brightnessViewModelProperty.set(-1f)
-                } else if (isOnStageableProperty.lastValueRetrievedFromHub == true) {
+                } else if (isOnStageableProperty.stagedValueOrLastValueFromHub == true) {
                     Log.v("tinge", "LightsUiHelper controller brightness changed, isOn is true, updating slider")
                     brightnessViewModelProperty.set(brightnessStageableProperty.stagedValueOrLastValueFromHub)
                 } else {

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/LightsUiHelper.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/LightsUiHelper.kt
@@ -38,7 +38,7 @@ object LightsUiHelper {
                 } else if (value >= 0f){
                     Log.v("tinge", "LightsUiHelper brightness slider changed, setting light controller brightness to: "+value)
                     isOnStageableProperty.stageValue(true)
-                    brightnessStageableProperty.stageValue(value?:0f)
+                    brightnessStageableProperty.stageValue(value)
                 }
                 isPropertyBeingChangedByCode = false
             }
@@ -105,32 +105,55 @@ object LightsUiHelper {
                 lightController?.hue?.stagedValueOrLastValueFromHub,
                 lightController?.saturation?.stagedValueOrLastValueFromHub,
                 lightController?.brightness?.stagedValueOrLastValueFromHub,
-                lightController?.isOn?.stagedValueOrLastValueFromHub)
+                lightController?.isOn?.stagedValueOrLastValueFromHub,
+                lightController?.isReachable?.get())
     }
 
     /**
      * Gets the preview image tint colour to use in the UI, given the current setup of a light.
      * */
-    fun getPreviewImageTintColourFromLightColour(hue: Float?, saturation: Float?, brightness: Float?, isOn: Boolean?): Int {
+    fun getPreviewImageTintColourFromLightColour(
+            hue: Float?, saturation: Float?, brightness: Float?,
+            isOn: Boolean?, isReachable: Boolean?): Int {
         return if (isOn == true)
             ColorHelper.colorFromHsv(
                     hue ?: 0f,
                     saturation ?: 0f,
-                    0.5f + 0.5f * (brightness ?: 0f))
-        else ColorHelper.colorFromHsv(0f, 0f, 0.2f)
+                    0.5f + 0.5f * (brightness ?: 0f),
+                    (if (isReachable == true) 1.0f else 0.5f))
+        else ColorHelper.colorFromHsv(
+                0f, 0f, 0.2f,
+                (if (isReachable == true) 1.0f else 0.5f))
+    }
+
+    /**
+     * Gets the faded background colour to use in the UI, given a light.
+     * */
+    fun getFadedBackgroundColourFromLightController(lightController: LightController?): Int {
+        return getFadedBackgroundColourFromLightColour(
+                lightController?.hue?.stagedValueOrLastValueFromHub,
+                lightController?.saturation?.stagedValueOrLastValueFromHub,
+                lightController?.brightness?.stagedValueOrLastValueFromHub,
+                lightController?.isOn?.stagedValueOrLastValueFromHub,
+                lightController?.isReachable?.get())
     }
 
     /**
      * Gets the faded background colour to use in the UI, given the current setup of a light.
      * */
-    fun getFadedBackgroundColourFromLightColour(hue: Float?, saturation: Float?, brightness: Float?, isOn: Boolean?): Int {
+    fun getFadedBackgroundColourFromLightColour(
+            hue: Float?, saturation: Float?, brightness: Float?,
+            isOn: Boolean?, isReachable: Boolean?): Int {
         return if (isOn == true) {
             ColorHelper.colorFromHsv(
                     hue ?: 0f,
                     (saturation ?: 0f) * 0.225f * (0.5f + 0.5f * (brightness ?: 0f)),
-                    1.0f)
+                    1.0f,
+                    (if (isReachable == true) 1.0f else 0.5f))
         } else {
-            ColorHelper.colorFromHsv(0f, 0f, 0.93f)
+            ColorHelper.colorFromHsv(
+                    0f, 0f, 0.93f,
+                    (if (isReachable == true) 1.0f else 0.5f))
         }
     }
 

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
@@ -171,6 +171,13 @@ class GroupView @JvmOverloads constructor(
 
         val paint = Paint()
 
+        var numberOfLightsToShow = viewModel?.lightGroupController?.lightsNotInSubgroup?.
+                count { it.isReachable.get() == true } ?: 0
+        val includeUnreachableLights = numberOfLightsToShow == 0
+        if (includeUnreachableLights) {
+            numberOfLightsToShow = viewModel?.lightGroupController?.lightsNotInSubgroup?.size ?: 0
+        }
+
         if (individualLightBitmaps.size == 1) {
             val bitmap = individualLightBitmaps.get(0)
             canvas.drawBitmap(bitmap,
@@ -181,9 +188,16 @@ class GroupView @JvmOverloads constructor(
                     viewModel?.lightGroupController?.lightsNotInSubgroup?.getOrNull(0)),
                     PorterDuff.Mode.MULTIPLY)
         } else {
+            var drawnLightI = 0
             individualLightBitmaps.forEachIndexed { i, bitmap ->
-                val startAngle = Math.PI * 2 * i / individualLightBitmaps.size
-                val endAngle = Math.PI * 2 * (i + 1) / individualLightBitmaps.size
+                val lightController = viewModel?.lightGroupController?.lightsNotInSubgroup?.getOrNull(i)
+
+                if (lightController?.isReachable?.get() != true && !includeUnreachableLights) {
+                    return@forEachIndexed
+                }
+
+                val startAngle = Math.PI * 2 * drawnLightI / numberOfLightsToShow
+                val endAngle = Math.PI * 2 * (drawnLightI + 1) / numberOfLightsToShow
                 val midAngle = startAngle * 0.5 + endAngle * 0.5
 
                 val path = Path()
@@ -208,10 +222,12 @@ class GroupView @JvmOverloads constructor(
 
                 canvas.drawColor(
                         LightsUiHelper.getPreviewImageTintColourFromLightController(
-                                viewModel?.lightGroupController?.lightsNotInSubgroup?.getOrNull(i)),
+                                lightController),
                         PorterDuff.Mode.MULTIPLY)
 
                 canvas.restore()
+
+                drawnLightI += 1
             }
         }
 

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
@@ -150,11 +150,7 @@ class GroupView @JvmOverloads constructor(
         val weightedColors = ArrayList<WeightedStripedColorDrawable.GlassToolbarWeightedColor>()
 
         viewModel?.lightGroupController?.lightsNotInSubgroup?.forEach {
-            val colour = LightsUiHelper.getFadedBackgroundColourFromLightColour(
-                    it.hue.stagedValueOrLastValueFromHub,
-                    it.saturation.stagedValueOrLastValueFromHub,
-                    it.brightness.stagedValueOrLastValueFromHub,
-                    it.isOn.stagedValueOrLastValueFromHub)
+            val colour = LightsUiHelper.getFadedBackgroundColourFromLightController(it)
             val weight = if (it.isOn.stagedValueOrLastValueFromHub != true) 0.5f else 1f
             weightedColors.add(WeightedStripedColorDrawable.GlassToolbarWeightedColor(colour, 0f, weight))
         }

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupView.kt
@@ -151,7 +151,10 @@ class GroupView @JvmOverloads constructor(
 
         viewModel?.lightGroupController?.lightsNotInSubgroup?.forEach {
             val colour = LightsUiHelper.getFadedBackgroundColourFromLightController(it)
-            val weight = if (it.isOn.stagedValueOrLastValueFromHub != true) 0.5f else 1f
+            val weight =
+                    if (it.isReachable.get() != true) 0.35f
+                    else if (it.isOn.stagedValueOrLastValueFromHub != true) 0.5f
+                    else 1f
             weightedColors.add(WeightedStripedColorDrawable.GlassToolbarWeightedColor(colour, 0f, weight))
         }
         backgroundDrawable.weightedColors = weightedColors

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupViewModel.kt
@@ -123,7 +123,8 @@ class GroupViewModel(
                         meanHue.get(), meanSaturation.get(), meanBrightness.get(),
                         lightGroupController.lightsNotInSubgroup.any {
                             it.isOn.stagedValueOrLastValueFromHub == true
-                        }))
+                        },
+                        true))
     }
 
     private fun updateMeanProperties() {

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/groupView/GroupViewModel.kt
@@ -37,6 +37,8 @@ class GroupViewModel(
 
     override val secondaryInformation = ObservableField<String?>("")
 
+    override val isReachable = ObservableField<Boolean>(true)
+
     val meanBrightness = ObservableField<Float>(0f)
     val meanHue = ObservableField<Float>(0f)
     val meanSaturation = ObservableField<Float>(0f)
@@ -230,9 +232,7 @@ class GroupViewModel(
                         lightViewModel.lightController == lightController
                     },
                     {
-                        //if (it.lightController.hubController == hubController) {
                         individualLightViewModels.remove(it)
-                        //}
                     },
                     {
                         val lightViewModel = LightViewModel(it)

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
@@ -101,7 +101,12 @@ class LightViewModel(
                 updateBrightnessSliderColor()
                 updateExpandedFunctionalityVisibility()
             }
+        })
 
+        lightController.isReachable.addOnPropertyChangedCallback(object: Observable.OnPropertyChangedCallback() {
+            override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
+                updateExpandedFunctionalityVisibility()
+            }
         })
 
 
@@ -144,7 +149,9 @@ class LightViewModel(
     }
 
     private fun updateExpandedFunctionalityVisibility() {
-        if (brightnessAndIsOnObservable.get() ?: 0f < 0f) {
+        if (lightController.isReachable.get() != true) {
+            showTopRightExpandButton.set(true)
+        } else if (brightnessAndIsOnObservable.get() ?: 0f < 0f) {
             showTopRightExpandButton.set(false)
             isExpanded.set(false)
         } else {

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
@@ -114,17 +114,9 @@ class LightViewModel(
 
     private fun updateColorsFromHsv() {
         colorForPreviewImageView.set(
-                LightsUiHelper.getPreviewImageTintColourFromLightColour(
-                        hueObservable.get(),
-                        saturationObservable.get(),
-                        brightnessAndIsOnObservable.get(),
-                        brightnessAndIsOnObservable.get() ?: -1f >= 0f))
+                LightsUiHelper.getPreviewImageTintColourFromLightController(lightController))
         colorForBackgroundView.set(
-                LightsUiHelper.getFadedBackgroundColourFromLightColour(
-                        hueObservable.get(),
-                        saturationObservable.get(),
-                        brightnessAndIsOnObservable.get(),
-                        brightnessAndIsOnObservable.get() ?: -1f >= 0f))
+                LightsUiHelper.getFadedBackgroundColourFromLightController(lightController))
     }
 
     private fun updateHueSliderColor() {

--- a/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
+++ b/app/src/main/java/com/thaddeussoftware/tinge/ui/lights/lightView/LightViewModel.kt
@@ -26,17 +26,16 @@ class LightViewModel(
 
     override val doesSupportColorMode = ObservableField<Boolean>(lightController.doesSupportColorMode)
 
-    /*override val hue = lightController.hue.stagedValueOrLastValueFromHubObservable
-    override val saturation = lightController.saturation.stagedValueOrLastValueFromHubObservable
-    override val brightness = ObservableField<Float?>()
+    override val displayName = lightController.displayName.stagedValueOrLastValueFromHubObservable
 
-    /**The amount that the white slider should be at*/
-    override val whiteTemperature = ObservableField<Float?>()*/
+    override val isReachable = lightController.isReachable
+
 
     override val hueHandles = ObservableArrayList<SliderViewHandle>()
     override val saturationHandles = ObservableArrayList<SliderViewHandle>()
     override val brightnessHandles = ObservableArrayList<SliderViewHandle>()
     override val whiteTemperatureHandles = ObservableArrayList<SliderViewHandle>()
+
 
     override val isExpanded = ObservableField<Boolean>(false)
 
@@ -45,8 +44,6 @@ class LightViewModel(
     override val colorForPreviewImageView = ObservableField<Int>(0)
 
     override val colorForBackgroundView = ObservableField<Int>(0)
-
-    override val displayName = lightController.displayName.stagedValueOrLastValueFromHubObservable
 
     override val secondaryInformation = ObservableField<String?>("")
 
@@ -135,7 +132,7 @@ class LightViewModel(
     }
 
     private fun updateSaturationSliderColor() {
-        val color2 = getColorFromHsv(hueObservable.get()?: 0f, 1f, 1f)
+        val color2 = ColorHelper.colorFromHsv(hueObservable.get()?: 0f, 1f, 1f)
 
         saturationHandles[0].color.set(ColorUtils.blendARGB(0xffeeeeee.toInt(), color2,
                 saturationObservable.get()?:1f))
@@ -175,9 +172,6 @@ class LightViewModel(
         isInColorMode.set(false)
     }
 
-
-
-    private fun getColorFromHsv(h:Float, s:Float, v:Float) = Color.HSVToColor(floatArrayOf(h*360f, s, v))
 
     fun getColorFromWhiteAmount(whiteAmount: Double): Int {
         val temperature = (2000.0+6500.0*whiteAmount)/100.0

--- a/app/src/main/res/drawable/unreachable_text_background_view.xml
+++ b/app/src/main/res/drawable/unreachable_text_background_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:radius="4dp"/>
+    <solid
+        android:color="#44000000"/>
+</shape>

--- a/app/src/main/res/layout/view_inner_light.xml
+++ b/app/src/main/res/layout/view_inner_light.xml
@@ -101,6 +101,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
 
+            android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
 
             android:text="@{viewModel.displayName}"
             android:textSize="@dimen/list_view_title_font_size"
@@ -120,6 +121,7 @@
             android:layout_height="wrap_content"
 
             android:visibility="@{viewModel.isReachable() ? View.GONE : View.VISIBLE}"
+            android:alpha="0.5"
 
             android:background="@drawable/unreachable_text_background_view"
             android:paddingLeft="4dp"
@@ -163,6 +165,7 @@
             style="@style/ListViewSliderImage"
             android:layout_marginTop="0dp"
             android:contentDescription="@string/accessibility_brightness"
+            android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
 
             android:src="@drawable/ic_brightness_5_black_24dp"
             app:layout_constraintLeft_toLeftOf="@+id/content_start_space"
@@ -172,6 +175,7 @@
             android:id="@+id/brightness_seek_bar"
 
             app:handles="@{viewModel.brightnessHandles}"
+            android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
 
             app:offValueText="Off"
             app:supportsOffValue="true"

--- a/app/src/main/res/layout/view_inner_light.xml
+++ b/app/src/main/res/layout/view_inner_light.xml
@@ -30,8 +30,8 @@
 
             app:cardCornerRadius="@{ 0.15f * (isGroup ? @dimen/view_group_left_image_width : @dimen/view_light_left_image_width) }"
 
-            android:layout_width="@{ isGroup ? @dimen/view_group_left_image_width : @dimen/view_light_left_image_width, default = wrap_content}"
-            android:layout_height="@{ isGroup ? @dimen/view_group_left_image_width : @dimen/view_light_left_image_width, default = wrap_content}"
+            android:layout_width="@{ isGroup ? @dimen/view_group_left_image_width : (!viewModel.isReachable() &amp;&amp; !viewModel.isExpanded()) ? @dimen/view_light_unreachable_image_width : @dimen/view_light_left_image_width, default = wrap_content}"
+            android:layout_height="@{ isGroup ? @dimen/view_group_left_image_width : (!viewModel.isReachable() &amp;&amp; !viewModel.isExpanded()) ? @dimen/view_light_unreachable_image_width : @dimen/view_light_left_image_width, default = wrap_content}"
             android:layout_marginTop="@dimen/list_view_inner_top_padding"
             tools:layout_width="50dp"
             tools:layout_height="50dp"
@@ -165,7 +165,7 @@
             style="@style/ListViewSliderImage"
             android:layout_marginTop="0dp"
             android:contentDescription="@string/accessibility_brightness"
-            android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
+            android:visibility="@{ safeUnbox(viewModel.isExpanded() || viewModel.isReachable()) ? View.VISIBLE : View.GONE }"
 
             android:src="@drawable/ic_brightness_5_black_24dp"
             app:layout_constraintLeft_toLeftOf="@+id/content_start_space"
@@ -175,7 +175,7 @@
             android:id="@+id/brightness_seek_bar"
 
             app:handles="@{viewModel.brightnessHandles}"
-            android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
+            android:visibility="@{ safeUnbox(viewModel.isExpanded() || viewModel.isReachable()) ? View.VISIBLE : View.GONE }"
 
             app:offValueText="Off"
             app:supportsOffValue="true"
@@ -321,6 +321,26 @@
             app:layout_constraintLeft_toLeftOf="@+id/brightness_seek_bar"
             app:layout_constraintRight_toRightOf="@+id/brightness_seek_bar"
             app:layout_constraintTop_toTopOf="@+id/white_image_view" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/below_controls_barrier"
+            app:constraint_referenced_ids="white_seek_view,saturation_seek_bar"
+            app:barrierDirection="bottom"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"/>
+
+        <TextView
+            android:textSize="@dimen/list_view_title_font_size"
+            android:textColor="#aa000000"
+            android:text="@string/light_unreachable_disclaimer"
+
+            android:visibility="@{!viewModel.isReachable() &amp;&amp; viewModel.isExpanded() ? View.VISIBLE : View.GONE}"
+
+            app:layout_constraintStart_toStartOf="@+id/brightness_image_view"
+            app:layout_constraintEnd_toEndOf="@+id/brightness_seek_bar"
+            app:layout_constraintTop_toBottomOf="@+id/below_controls_barrier"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"/>
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_inner_light.xml
+++ b/app/src/main/res/layout/view_inner_light.xml
@@ -52,6 +52,16 @@
 
         </androidx.cardview.widget.CardView>
 
+        <Space
+            android:id="@+id/content_start_space"
+
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="@dimen/list_view_inner_image_text_horizontal_margin"
+
+            app:layout_constraintStart_toEndOf="@+id/left_image_view_holder"
+            app:layout_constraintTop_toTopOf="parent"/>
+
 
         <!--
         EXPAND/CONTRACT BUTTON:
@@ -65,13 +75,14 @@
             android:onClick="@{ viewModel::onExpandContractButtonClicked }"
 
             android:clickable="true"
+            android:focusable="true"
             android:foreground="?android:attr/selectableItemBackground"
 
             android:layout_width="@dimen/list_view_expand_contract_image_size"
             android:layout_height="@dimen/list_view_expand_contract_image_size"
             android:padding="@dimen/list_view_expand_contract_image_padding"
             android:layout_marginTop="@dimen/list_view_expand_contract_image_top_margin"
-            android:layout_marginRight="@dimen/list_view_expand_contract_image_right_margin"
+            android:layout_marginEnd="@dimen/list_view_expand_contract_image_right_margin"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="@+id/left_image_view_holder"
@@ -79,7 +90,7 @@
             />
 
         <!--
-        TITLE:
+        TITLE, DESCRIPTION AND UNREACHABLE TEXT:
         -->
 
         <TextView
@@ -88,16 +99,39 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
 
-            android:layout_marginStart="@dimen/list_view_inner_image_text_horizontal_margin"
+
             android:text="@{viewModel.displayName}"
             android:textSize="@dimen/list_view_title_font_size"
             android:textColor="#000000"
             app:layout_constraintEnd_toStartOf="@+id/expand_contract_button"
-            app:layout_constraintStart_toEndOf="@+id/left_image_view_holder"
+            app:layout_constraintStart_toEndOf="@+id/unreachable_text_view"
             android:layout_marginTop="@dimen/list_view_inner_top_padding"
+            android:layout_marginLeft="@{viewModel.isReachable() ? 0f : 4f * @dimen/dimen_1dp}"
             app:layout_constraintTop_toTopOf="parent"
 
             tools:text="Light name"/>
+
+        <TextView
+            android:id="@+id/unreachable_text_view"
+
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+
+            android:visibility="@{viewModel.isReachable() ? View.GONE : View.VISIBLE}"
+
+            android:background="@drawable/unreachable_text_background_view"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:paddingBottom="1dp"
+            android:textStyle="bold"
+
+            android:layout_marginTop="@{@dimen/list_view_inner_top_padding + 1f*@dimen/dimen_1dp}"
+            android:text="@string/light_unreachable"
+            android:textSize="13sp"
+            android:textColor="#000000"
+            app:layout_constraintStart_toEndOf="@+id/content_start_space"
+            app:layout_constraintTop_toTopOf="parent"
+            />
 
         <TextView
             android:id="@+id/description_text_view"
@@ -128,7 +162,7 @@
             android:layout_marginTop="0dp"
 
             android:src="@drawable/ic_brightness_5_black_24dp"
-            app:layout_constraintLeft_toLeftOf="@+id/title_text_view"
+            app:layout_constraintLeft_toLeftOf="@+id/content_start_space"
             app:layout_constraintTop_toBottomOf="@+id/description_text_view" />
 
         <com.thaddeussoftware.tinge.ui.sliderView.SliderView
@@ -145,8 +179,8 @@
 
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/list_view_image_slider_horizontal_separation"
-            android:layout_marginRight="20dp"
+            android:layout_marginStart="@dimen/list_view_image_slider_horizontal_separation"
+            android:layout_marginEnd="20dp"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintBottom_toBottomOf="@+id/brightness_image_view"
             app:layout_constraintLeft_toRightOf="@+id/brightness_image_view"
@@ -162,7 +196,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/list_view_inner_inbetween_vertical_margin"
                 app:cardBackgroundColor="#00ffffff"
-                app:layout_constraintLeft_toLeftOf="@+id/title_text_view"
+                app:layout_constraintLeft_toLeftOf="@+id/content_start_space"
                 app:layout_constraintRight_toRightOf="@+id/title_text_view"
                 app:layout_constraintTop_toBottomOf="@+id/brightness_seek_bar">
 
@@ -211,7 +245,7 @@
 
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/list_view_image_slider_horizontal_separation"
+            android:layout_marginStart="@dimen/list_view_image_slider_horizontal_separation"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintBottom_toBottomOf="@+id/hue_image_view"
             app:layout_constraintLeft_toLeftOf="@+id/brightness_seek_bar"
@@ -243,7 +277,7 @@
             android:layout_height="wrap_content"
             android:paddingLeft="0dp"
             android:paddingRight="0dp"
-            android:layout_marginLeft="@dimen/list_view_image_slider_horizontal_separation"
+            android:layout_marginStart="@dimen/list_view_image_slider_horizontal_separation"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintBottom_toBottomOf="@+id/saturation_image_view"
             app:layout_constraintLeft_toLeftOf="@+id/brightness_seek_bar"
@@ -271,7 +305,7 @@
             android:layout_height="wrap_content"
             android:paddingLeft="0dp"
             android:paddingRight="0dp"
-            android:layout_marginLeft="@dimen/list_view_image_slider_horizontal_separation"
+            android:layout_marginStart="@dimen/list_view_image_slider_horizontal_separation"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintBottom_toBottomOf="@+id/white_image_view"
             app:layout_constraintLeft_toLeftOf="@+id/brightness_seek_bar"

--- a/app/src/main/res/layout/view_inner_light.xml
+++ b/app/src/main/res/layout/view_inner_light.xml
@@ -106,7 +106,7 @@
             app:layout_constraintEnd_toStartOf="@+id/expand_contract_button"
             app:layout_constraintStart_toEndOf="@+id/unreachable_text_view"
             android:layout_marginTop="@dimen/list_view_inner_top_padding"
-            android:layout_marginLeft="@{viewModel.isReachable() ? 0f : 4f * @dimen/dimen_1dp}"
+            android:layout_marginStart="@{viewModel.isReachable() ? 0f : 4f * @dimen/dimen_1dp}"
             app:layout_constraintTop_toTopOf="parent"
 
             tools:text="Light name"/>

--- a/app/src/main/res/layout/view_inner_light.xml
+++ b/app/src/main/res/layout/view_inner_light.xml
@@ -46,6 +46,7 @@
                 android:tint="@{ safeUnbox(viewModel.colorForPreviewImageView) }"
                 android:tintMode="multiply"
                 android:src="@drawable/top_light_image"
+                android:importantForAccessibility="no"
 
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
@@ -73,6 +74,7 @@
             android:src="@{ safeUnbox(viewModel.isExpanded()) ? @drawable/ic_expand_less_black_24dp : @drawable/ic_expand_more_black_24dp , default = @drawable/ic_expand_less_black_24dp}"
             android:visibility="@{ safeUnbox(viewModel.showTopRightExpandButton) ? View.VISIBLE : View.GONE}"
             android:onClick="@{ viewModel::onExpandContractButtonClicked }"
+            android:contentDescription="@{ safeUnbox(viewModel.isExpanded()) ? @string/accessibility_contract : @string/accessibility_expand }"
 
             android:clickable="true"
             android:focusable="true"
@@ -160,6 +162,7 @@
 
             style="@style/ListViewSliderImage"
             android:layout_marginTop="0dp"
+            android:contentDescription="@string/accessibility_brightness"
 
             android:src="@drawable/ic_brightness_5_black_24dp"
             app:layout_constraintLeft_toLeftOf="@+id/content_start_space"
@@ -225,6 +228,7 @@
             android:id="@+id/hue_image_view"
 
             android:visibility="@{ safeUnbox(viewModel.isInColorMode()) &amp;&amp; safeUnbox(viewModel.isExpanded()) ? View.VISIBLE : View.GONE }"
+            android:contentDescription="@string/accessibility_hue"
 
             style="@style/ListViewSliderImage"
             android:layout_marginTop="@dimen/list_view_inner_inbetween_vertical_margin"
@@ -256,6 +260,7 @@
             android:id="@+id/saturation_image_view"
 
             android:visibility="@{ safeUnbox(viewModel.isInColorMode()) &amp;&amp; safeUnbox(viewModel.isExpanded()) ? View.VISIBLE : View.GONE }"
+            android:contentDescription="@string/accessibility_saturation"
 
             style="@style/ListViewSliderImage"
             android:layout_marginTop="@dimen/list_view_inner_inbetween_vertical_margin"
@@ -288,6 +293,7 @@
             android:id="@+id/white_image_view"
 
             android:visibility="@{ !safeUnbox(viewModel.isInColorMode()) &amp;&amp; safeUnbox(viewModel.isExpanded()) ? View.VISIBLE : View.GONE }"
+            android:contentDescription="@string/accessibility_white_tint"
 
             style="@style/ListViewSliderImage"
             android:layout_marginTop="@dimen/list_view_inner_inbetween_vertical_margin"

--- a/app/src/main/res/layout/view_light.xml
+++ b/app/src/main/res/layout/view_light.xml
@@ -13,7 +13,6 @@
 
     <FrameLayout
         android:background="@{viewModel.colorForBackgroundView}"
-        android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
 
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/app/src/main/res/layout/view_light.xml
+++ b/app/src/main/res/layout/view_light.xml
@@ -13,6 +13,7 @@
 
     <FrameLayout
         android:background="@{viewModel.colorForBackgroundView}"
+        android:alpha="@{viewModel.isReachable() ? 1f : 0.5f}"
 
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -33,6 +33,7 @@
 
     <dimen name="view_light_left_image_width">38dp</dimen>
     <dimen name="view_group_left_image_width">56dp</dimen>
+    <dimen name="view_light_unreachable_image_width">22dp</dimen>
 
     <dimen name="fragment_connect_to_hub_horizontal_still_searching_padding">8dp</dimen>
     <dimen name="fragment_connect_to_hub_padding_above_large_image">8dp</dimen>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_background">#2D2D2D</color>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,11 @@
     <string name="group_info_some_on">%s$1 lights on</string>
 
     <string name="light_unreachable">Unreachable</string>
+
+    <string name="accessibility_brightness">Brightness</string>
+    <string name="accessibility_hue">Hue</string>
+    <string name="accessibility_saturation">Brightness</string>
+    <string name="accessibility_white_tint">White temperature</string>
+    <string name="accessibility_expand">Expand additional properties</string>
+    <string name="accessibility_contract">Hide additional properties</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,6 @@
     <string name="group_info_all_on">All lights on</string>
     <string name="group_info_one_on">%s$1 light on</string>
     <string name="group_info_some_on">%s$1 lights on</string>
+
+    <string name="light_unreachable">Unreachable</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="group_info_some_on">%s$1 lights on</string>
 
     <string name="light_unreachable">Unreachable</string>
+    <string name="light_unreachable_disclaimer">This light is unreachable, but you can try to adjust it anyway.</string>
 
     <string name="accessibility_brightness">Brightness</string>
     <string name="accessibility_hue">Hue</string>


### PR DESCRIPTION
Amend display of unreachable lights in UI:

- Unreachable lights show up smaller than regular lights in the list, are 50% transparent, have an unreachable label, and don't have a brightness slider initially visible.
- They can still be expanded if users want to modify their properties anyway, and text will be shown again informing them that the light is unreachable.
- Unreachable lights show up much smaller in the background of GroupViews.
- Unreachable lights don't show up in the left image of GroupViews, unless all the lights in that GroupView are unreachable.

![unreachable lights](https://user-images.githubusercontent.com/6856689/67628094-3d412200-f858-11e9-9149-6801291cde94.png)

Closes #14 

Tests have been added around the LightViewModel properties that have changed as a result of this.

Also, these tests revealed bugs in the combined isOn / brightness observables from LightsUiHelper.bindObservableBrightnessViewModelPropertyToController:
- This was using lastValueReceivedFromHub always, rather than using stagedValue when more recent.
- This was sometimes staging values on the isOn / brightness observables which were the same as lastValueReceivedFromHub.

These bugs have been fixed and tests added around these.

Fixing these bugs also resolves the issue with GroupView sliders getting out of sync when moved rapidly - closes #4 
